### PR TITLE
Configure renovate to update meshtastic-android AIDL libraries

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -309,16 +309,14 @@ dependencies {
     implementation 'com.alphacephei:vosk-android:0.3.47@aar'
     implementation project(':models')
 
-    def meshtasticVersion = "v2.7.13"
-
     // The underlying Protobuf definitions
-    implementation "com.github.meshtastic.Meshtastic-Android:meshtastic-android-proto:${meshtasticVersion}"
+    implementation "com.github.meshtastic.Meshtastic-Android:meshtastic-android-proto:v2.7.13"
 
     // The Parcelable data models (DataPacket, MeshUser, NodeInfo, etc.)
-    implementation "com.github.meshtastic.Meshtastic-Android:meshtastic-android-model:${meshtasticVersion}"
+    implementation "com.github.meshtastic.Meshtastic-Android:meshtastic-android-model:v2.7.13"
 
     // The core AIDL interface (IMeshService)
-    implementation "com.github.meshtastic.Meshtastic-Android:meshtastic-android-api:${meshtasticVersion}"
+    implementation "com.github.meshtastic.Meshtastic-Android:meshtastic-android-api:v2.7.13"
 
 
     // Osmdroid & Maps

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,20 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "excludePackagePrefixes": [
+        "com.github.meshtastic"
+      ],
+      "enabled": false
+    },
+    {
+      "matchPackagePrefixes": [
+        "com.github.meshtastic"
+      ],
+      "allowedVersions": "/^v\\d+\\.\\d+\\.\\d+$/",
+      "groupName": "Meshtastic Dependencies"
+    }
   ]
 }


### PR DESCRIPTION
This pull request introduces configuration changes to improve dependency management and version control for Meshtastic-related packages. The most important changes include updating how Meshtastic dependencies are referenced in `app/build.gradle` and adding a new `renovate.json` file to customize Renovate Bot behavior.

Dependency versioning improvements:

* Updated `app/build.gradle` to reference Meshtastic dependencies directly using the version string `v2.7.13`, instead of using a variable, for `meshtastic-android-proto`, `meshtastic-android-model`, and `meshtastic-android-api`.

Automated dependency management configuration:

* Added `renovate.json` to configure Renovate Bot, including rules to disable updates for Meshtastic dependencies and to group them for easier management, while enforcing allowed version patterns.