### PR TITLE
fix(constants): bind to MeshService at new org.meshtastic.core.service package

### DIFF
--- a/app/src/main/java/com/atakmap/android/meshtastic/util/Constants.java
+++ b/app/src/main/java/com/atakmap/android/meshtastic/util/Constants.java
@@ -3,9 +3,20 @@ package com.atakmap.android.meshtastic.util;
 public final class Constants {
     private Constants() {}
 
-    // Service Connection
+    // Service Connection.
+    // PACKAGE_NAME stays at com.geeksville.mesh — that's the Meshtastic
+    // Android app's applicationId (see the app's build.gradle), unchanged.
+    // CLASS_NAME tracks the foreground service class. In Meshtastic Android
+    // v2.7.14 the service class was repackaged from
+    // com.geeksville.mesh.service.MeshService to
+    // org.meshtastic.core.service.MeshService as part of the multi-module
+    // KMP refactor. The plugin's MeshServiceManager already imports the new
+    // org.meshtastic.core.service.IMeshService AIDL stub; the bind-target
+    // class name needed to match. Without this fix, bindService() silently
+    // fails to resolve the component on Meshtastic Android 2.7.14+.
+    // See: https://github.com/meshtastic/ATAK-Plugin/issues/111
     public static final String PACKAGE_NAME = "com.geeksville.mesh";
-    public static final String CLASS_NAME = "com.geeksville.mesh.service.MeshService";
+    public static final String CLASS_NAME = "org.meshtastic.core.service.MeshService";
     
     // Actions
     public static final String ACTION_MESH_CONNECTED = "com.geeksville.mesh.MESH_CONNECTED";


### PR DESCRIPTION
## Problem

Closes / addresses (in part) #111. Plugin v1.1.42 fails to bind `IMeshService` on Meshtastic-Android 2.7.14+ because `Constants.CLASS_NAME` still hardcodes the pre-refactor service class path.

## Root cause

In Meshtastic-Android v2.7.14 the foreground `MeshService` class was repackaged from `com.geeksville.mesh.service.MeshService` to `org.meshtastic.core.service.MeshService` as part of the multi-module KMP refactor.

`MeshServiceManager.java` has already been updated to import the new `org.meshtastic.core.service.IMeshService` AIDL stub — but the bind-target string in `Constants.CLASS_NAME` was left pointing at the old class path. So:

```java
serviceIntent.setClassName(Constants.PACKAGE_NAME, Constants.CLASS_NAME);
context.bindService(serviceIntent, ...);
```

…silently fails to resolve the component on Meshtastic-Android 2.7.14+ because no `com.geeksville.mesh.service.MeshService` exists in the target app anymore.

## Fix

Update `Constants.CLASS_NAME` to `org.meshtastic.core.service.MeshService` (matches the new declaration in the Android app's manifest). `PACKAGE_NAME` is unchanged — the app's `applicationId` is still `com.geeksville.mesh`; only the service class moved.

## Companion PR (required)

This PR alone is not sufficient. Meshtastic-Android v2.7.14+ also dropped `android:exported="true"` and the canonical intent-filter from the service declaration in the same release window, which makes cross-app `bindService()` impossible regardless of class name. A companion PR is open against `meshtastic/Meshtastic-Android` restoring those two attributes:

- **meshtastic/Meshtastic-Android#5947** — restore `exported="true"` + intent-filter

Both PRs need to land for the plugin to bind on Meshtastic-Android 2.7.14+. After both ship, the documented workaround (downgrade Meshtastic-Android to 2.7.13, per the #111 thread) becomes unnecessary.

## Verified

Production usage at `training.ticketscad.com` (ATAK CIV 5.6.0.12 + Heltec V3 firmware 2.7.26 + plugin v1.1.42). With Meshtastic-Android 2.7.13 the plugin binds successfully; with 2.7.14 it fails. Updating `Constants.CLASS_NAME` alone is not enough on 2.7.14 because of the export-flag issue — only after the paired Meshtastic-Android PR also lands does this patch result in a successful bind.